### PR TITLE
[dart_lsc] Prepare for 1.0.0 version of sensors and package_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+* Prepare for 1.0.0 version of sensors and package_info. ([dart_lsc](http://github.com/amirh/dart_lsc))
+
 ## 0.2.0
 
 * AndroidX Support

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: get_version
 description: Get the Version Name, Version Code, Platform and OS Version, and App ID on iOS and Android.
-version: 0.2.1
+version: 0.2.2
 author: Rody Davis <rody.davis.jr@gmail.com>
 homepage: https://github.com/fluttercommunity/get_version
 maintainer: Rody Davis (@rodydavis)
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  package_info: ^0.4.0+13
+  package_info: '>=0.4.0+13 <2.0.0'
 
 flutter:
   plugin:


### PR DESCRIPTION
This should be a safe change, for more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0

This change was auto generated by [dart_lsc](https://github.com/amirh/dart_lsc).